### PR TITLE
Fixed inconsistent optparse-declarative version

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -2,5 +2,5 @@ flags: {}
 packages:
   - '.'
 extra-deps:
-  - optparse-declarative-0.2.0
+  - optparse-declarative-0.3.0
 resolver: lts-2.14


### PR DESCRIPTION
`optparse-declarative`'s version in `stack.yaml` is older than the one in `hoe.cabal`.
